### PR TITLE
Schema/operator ifabsent default

### DIFF
--- a/define.yaml
+++ b/define.yaml
@@ -214,7 +214,7 @@ classes:
           - range: string
         required: false
       validityPeriod:
-        description: Time period during which the resouce is valid
+        description: Time period during which the resource is valid
         range: Timing
         required: false
 
@@ -2371,7 +2371,7 @@ enums:
       identifies the reference used in the genomic test in:
       indicates heritability of the genetic variant in:
       is an identifier for a published reference for the genetic variant in:
-      is an identifier for the copy, on one of two homologous chromosones, of the genetic variant in:
+      is an identifier for the copy, on one of two homologous chromosomes, of the genetic variant in:
       is an identifier for the genetic sequence of the genetic entity represented by:
       is the chromosome that is the position of the result in:
       is the clinical trial or treatment setting for:
@@ -2379,7 +2379,7 @@ enums:
       is the date of occurrence for:
       is the intended disease outcome for:
       is the method of secondary analysis of results in:
-      is the numeric location, within a chromosone, genetic entity, or genetic sub-region, of the result in:
+      is the numeric location, within a chromosome, genetic entity, or genetic sub-region, of the result in:
       is the symbol for the genomic entity that is the position of the result in:
       is the type of genomic entity that is the position of the result in:
       is the genetic sub-location of the result in:

--- a/define.yaml
+++ b/define.yaml
@@ -982,6 +982,7 @@ classes:
           Defaults to ALL if not specified.
         range: LogicalOperator
         required: false
+        ifabsent: LogicalOperator(AND)
       conditions:
         description: >-
           Child conditions to combine using the operator.
@@ -1035,6 +1036,7 @@ classes:
           Defaults to ALL if not specified.
         range: LogicalOperator
         required: false
+        ifabsent: LogicalOperator(AND)
 
   FormalExpression:
     description: >-


### PR DESCRIPTION
This PR encodes the default value for the `operator` slot in `define.yaml` using the LinkML `ifabsent` metaslot.

It also includes a couple of small typo fixes in schema descriptions.

## Changes

- Add `ifabsent: LogicalOperator(AND)` to the `operator` slot on `Condition`
- Add `ifabsent: LogicalOperator(AND)` to the `operator` slot on `RangeCheck`
- Fix `resouce` to `resource` in the `validityPeriod` description
- Fix two `chromosone` typos to `chromosome`